### PR TITLE
change max clock drift to 15 minutes

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -54,7 +54,7 @@ static const int fHaveUPnP = false;
 static const uint256 hashGenesisBlockOfficial("0x0000000032fe677166d54963b62a4677d8957e87c508eaa4fd7eb1c880cd27e3");
 static const uint256 hashGenesisBlockTestNet("0x00000001f757bb737f6596503e17cd17b0658ce630cc727c0cca81aec47c9f06");
 
-static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours
+static const int64 nMaxClockDrift = 2 * 15;        // fifteen minutes 
 
 extern CScript COINBASE_FLAGS;
 


### PR DESCRIPTION
benefits of this are better security vs. ability of someone to set their clock ahead and manipulate the chain
the only negative issue i see is people have to keep their clock within 15 minutes of time of blockchain or they cannot solve a block
there is no need for a two hour window