### PR TITLE
enable support for contemporary miniupnpc library.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -871,10 +871,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
I've noticed that ppcoin will not compile on modern Linux distributions and latest 10.11 OS X. This patch will fix it by adding support for modern libminiupnpc which is needed for upnp.